### PR TITLE
csrf error on edit form

### DIFF
--- a/src/wakawaka/templates/wakawaka/edit.html
+++ b/src/wakawaka/templates/wakawaka/edit.html
@@ -25,6 +25,7 @@
 
 	<form class="wakawaka_edit_form" method="POST" action="">
 		{{ form.as_p }}
+		{% csrf_token %}
 		<p>
             <input type="submit" value="{% trans "Save changes" %}" />
             {% trans "or" %} <a href="


### PR DESCRIPTION
A default install of wakawaka in a new django project was complaining about a csrf token not being supplied on the edit form.  This commit adds the csrf token and resolves the issue.
