### PR TITLE
Fixed deprecation warning for Django 1.10 for urls

### DIFF
--- a/wakawaka/urls/__init__.py
+++ b/wakawaka/urls/__init__.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 
 from wakawaka.views import *
@@ -9,7 +9,7 @@ from wakawaka.views import *
 WIKI_SLUG = r'((([A-Z]+[a-z]+){2,})(/([A-Z]+[a-z]+){2,})*)'
 WIKI_SLUG = getattr(settings, 'WAKAWAKA_SLUG_REGEX', WIKI_SLUG)
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', index, name='wakawaka_index'),
 
     # Revision and Page list
@@ -30,4 +30,4 @@ urlpatterns = patterns('',
     # Page
     url(r'^(?P<slug>%s)/rev(?P<rev_id>\d+)/$' % WIKI_SLUG, page, name='wakawaka_page'),
     url(r'^(?P<slug>%s)/$' % WIKI_SLUG, page, name='wakawaka_page'),
-)
+]

--- a/wakawaka/urls/__init__.py
+++ b/wakawaka/urls/__init__.py
@@ -6,7 +6,7 @@ from wakawaka.views import *
 
 # Wiki slugs must been CamelCase but slashes are fine, if each slug
 # is also a CamelCase/OtherSide
-WIKI_SLUG = r'((([A-Z]+[a-z]+){2,})(/([A-Z]+[a-z]+){2,})*)'
+WIKI_SLUG = r'((([A-Z]+[a-z]+){1,})(/([A-Z]+[a-z]+){1,})*)'
 WIKI_SLUG = getattr(settings, 'WAKAWAKA_SLUG_REGEX', WIKI_SLUG)
 
 urlpatterns = [


### PR DESCRIPTION
I'm not 100% sure if this breaks backwards compatibility with older versions of Django.  However, this patch removes a deprecation warning that appears in Django 1.9, involving the removal of django.conf.urls.patterns in Django 1.10.
