### PR TITLE
Add ability to use markdown

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,8 @@ framework.
 * It also has a quite comprehensive permission integration, taking care of
   Django's default create/edit/delete permissions.
 
-* Wakawaka is an application and indented to be placed in an existing project.
+* Wakawaka can be used as an application on its own, or included into an existing
+  project.
 
 Some screenshots from the *Example Project*:
 
@@ -73,6 +74,16 @@ change this behaviour by adding a setting ``WAKAWAKA_SLUG_REGEX`` to your
 settings.py. This holds a regular expression of the wiki name format. Default::
 
     WAKAWAKA_SLUG_REGEX = r'((([A-Z]+[a-z]+){2,})(/([A-Z]+[a-z]+){2,})*)'
+
+To add markdown (or reStructuredText) support you can specify a function to
+pass page content to before displaying it on the page. For example::
+
+    import markdown
+    WAKAWAKA_PREPROCESS_CONTENT_FUNCTION = markdown.markdown
+
+``WAKAWAKA_PREPROCESS_CONTENT_FUNCTION`` can be any python callable that takes
+a string and returns a string. It is applied before creating the internal wiki
+links.
 
 Attachments:
 ============

--- a/wakawaka/templates/wakawaka/page.html
+++ b/wakawaka/templates/wakawaka/page.html
@@ -29,7 +29,7 @@
 	{% endif %}
 
 	<div class="page">
-	{{ rev.content|urlize|wikify|linebreaks }}
+	{{ rev.content|preprocess_content|wikify }}
 	</div>
 
 	{% spaceless %}

--- a/wakawaka/tests/test_templatetags.py
+++ b/wakawaka/tests/test_templatetags.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from wakawaka.templatetags.wakawaka_tags import wikify
+from wakawaka.templatetags.wakawaka_tags import preprocess_content
 from wakawaka.tests.base import BaseTestCase
 
 
@@ -52,6 +53,32 @@ class TemplateTagTestCase(BaseTestCase):
         """
         f = wikify('Check WikiIndex out!')
         self.assertEqual(f, 'Check <a class="doesnotexist" href="/WikiIndex/edit/">WikiIndex</a> out!')
+
+    def test_default_preprocess_function_with_paragraphs(self):
+        """
+        By default, the content of a page has its line breaks converted
+        into paragraph tags, and urls are converted to anchor tags.
+        """
+        f = preprocess_content('Check WikiIndex out!\n\nIt features CarrotCake!')
+        self.assertEqual(f, '<p>Check WikiIndex out!</p>\n\n<p>It features CarrotCake!</p>')
+
+    def test_default_preprocess_function_with_urls(self):
+        f = preprocess_content('You can view the source code at https://github.com/bartTC/django-wakawaka')
+        self.assertEqual(f, '<p>You can view the source code at <a href="https://github.com/bartTC/django-wakawaka" rel="nofollow">https://github.com/bartTC/django-wakawaka</a></p>')
+
+    def test_custom_preprocess_function(self):
+        """
+        The default behaviour can be replaces with any python callable.
+        You can add support for markdown, rst, or even filter out bad
+        language. In this test, we want all pages to be displayed in
+        all caps.
+        """
+        def capitalise(value):
+            return value.upper()
+
+        with self.settings(WAKAWAKA_PREPROCESS_CONTENT_FUNCTION=capitalise):
+            f = preprocess_content('Check WikiIndex out!\n\nIt features CarrotCake!')
+            self.assertEqual(f, 'CHECK WIKIINDEX OUT!\n\nIT FEATURES CARROTCAKE!')
 
     def __defunctest_custom_wikiword_regex(self):
         """


### PR DESCRIPTION
One thing I really like about this wiki module was that it works out of the box with no dependencies, so I'm pretty keen to keep that.

Having said that in my particular use case, we need to be able to create pages with a bit of formatting like headings and tables.

This change wraps the urlize and linebreaks filters into new filter which can be overridden with a new function in settings.py. This preserves the default behavior, but means you can pretty easily add markdown support.