### PR TITLE
added support to enable app on django 3.0.X

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist=
     py{27}-django-{111}
     py{34,35,36,37}-django-{111,20}
     py{35,36,37}-django-{21}
+    py{35,36,37}-django-{30}
     end
 
 [testenv]
@@ -17,6 +18,7 @@ deps=
     django-111: django==1.11.*
     django-20: django==2.0.*
     django-21: django==2.1.*
+    django-30: django==3.0.*
     coverage
 
 [testenv:begin]

--- a/wakawaka/models.py
+++ b/wakawaka/models.py
@@ -1,13 +1,14 @@
 from __future__ import unicode_literals
 
+import six
+
 from django.conf import settings
 from django.db import models
-from django.utils.six import python_2_unicode_compatible
 from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 
 
-@python_2_unicode_compatible
+@six.python_2_unicode_compatible
 class WikiPage(models.Model):
     slug = models.CharField(_('slug'), max_length=255)
     created = models.DateTimeField(_('created'), auto_now_add=True)
@@ -26,7 +27,7 @@ class WikiPage(models.Model):
         return self.revisions.latest()
 
 
-@python_2_unicode_compatible
+@six.python_2_unicode_compatible
 class Revision(models.Model):
     page = models.ForeignKey(
         WikiPage, related_name='revisions', on_delete=models.CASCADE


### PR DESCRIPTION
I replaced the django.util.six with the six module. Updated the decorators.

In the tox file, added the support to test django 3.0.X. Ran it on all version from django using python 3.7. In all cases one test kept failing. Not sure if this is expected or not. 

Please check. If acceptable, I'd be grateful if this can be merged and a new release made so I can install from pip.